### PR TITLE
Issue #49 - Fix Typo in usda file

### DIFF
--- a/source/transforms/get-world-transforms/usda.usda
+++ b/source/transforms/get-world-transforms/usda.usda
@@ -1,4 +1,4 @@
-[py stdout]: #usda 1.0
+#usda 1.0
 (
     defaultPrim = "World"
 )


### PR DESCRIPTION
This PR resolves #49. The typo in the usda file at
https://github.com/NVIDIA-Omniverse/OpenUSD-Code-Samples/blob/4185bbfefbd617bcd02324a52316e9d40f572640/source/transforms/get-world-transforms/usda.usda#L1

has been fixed, removing `[py stdout]: `