### PR TITLE
Fix: Correct return value in vtarray sample #79

### DIFF
--- a/source/data-types/convert-vtarray-numpy/py_usd.py
+++ b/source/data-types/convert-vtarray-numpy/py_usd.py
@@ -6,7 +6,7 @@ from pxr import Vt
 
 
 def convert_vt_to_np(my_array: Vt.Vec3fArray) -> numpy.ndarray:
-    return numpy.array(my_vec3_array)
+    return numpy.array(my_array)
 
 
 #############


### PR DESCRIPTION
Fixes #79

## Description

This pull request corrects a bug in the `convert_vt_to_np` code sample, as described in Issue #79. The original function was incorrectly returning the input `VtArray` instead of the newly created NumPy array. This change corrects the `return` statement to point to the correct variable.

## Testing Done

As per the contribution guidelines, I have performed manual testing to verify this fix.

- I created a local Python script that imports the modified function.
- The script creates a sample `Vt.Vec3fArray` as input.
- I called the function and used an `assert` statement to confirm that the returned object's type is `numpy.ndarray`.
- I printed the output to visually confirm the data was converted correctly.

The test passed successfully, confirming the fix works as expected.